### PR TITLE
Remove whitespace between author and "," in PR title

### DIFF
--- a/PullRequestMonitor/View/PullRequestView.xaml
+++ b/PullRequestMonitor/View/PullRequestView.xaml
@@ -30,8 +30,8 @@
             </TextBlock.Inlines>
         </TextBlock>
         <TextBlock Grid.Row="1" Grid.Column="0" TextTrimming="CharacterEllipsis" Margin="2">
-            <Run Text="{Binding Mode=OneTime, Path=Author}" />
-            <Run Text=","/>
+            <Run Text="{Binding Mode=OneTime, Path=Author}"/><!--
+         --><Run Text=","/>
             <Run>
                 <Run.Style>
                     <Style TargetType="Run">


### PR DESCRIPTION
Whitespace was being interpreted as part of the text run.

Putting runs on the same lines is vulnerable to auto-format, so comment
the whitespace instead.